### PR TITLE
fix/null-safe-creation-update-dates

### DIFF
--- a/src/main/java/io/kestra/storage/gcs/GcsFileAttributes.java
+++ b/src/main/java/io/kestra/storage/gcs/GcsFileAttributes.java
@@ -5,6 +5,10 @@ import io.kestra.core.storages.FileAttributes;
 import lombok.Builder;
 import lombok.Value;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 @Value
 @Builder
 public class GcsFileAttributes implements FileAttributes {
@@ -15,12 +19,18 @@ public class GcsFileAttributes implements FileAttributes {
 
     @Override
     public long getLastModifiedTime() {
-        return blobInfo.getUpdateTimeOffsetDateTime().toInstant().toEpochMilli();
+        return Optional.ofNullable(blobInfo.getUpdateTimeOffsetDateTime())
+            .map(OffsetDateTime::toInstant)
+            .map(Instant::toEpochMilli)
+            .orElse(0L);
     }
 
     @Override
     public long getCreationTime() {
-        return blobInfo.getCreateTimeOffsetDateTime().toInstant().toEpochMilli();
+        return Optional.ofNullable(blobInfo.getCreateTimeOffsetDateTime())
+            .map(OffsetDateTime::toInstant)
+            .map(Instant::toEpochMilli)
+            .orElse(0L);
     }
 
     @Override

--- a/src/test/java/io/kestra/storage/gcs/GcsStorageTest.java
+++ b/src/test/java/io/kestra/storage/gcs/GcsStorageTest.java
@@ -4,6 +4,7 @@ import com.google.common.io.CharStreams;
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.utils.IdUtils;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.storages.StorageInterface;
 
@@ -204,6 +205,14 @@ class GcsStorageTest {
         List<FileAttributes> list = storageInterface.list(tenantId, new URI("/" + prefix + "/storage"));
 
         assertThat(list.stream().map(FileAttributes::getFileName).toList(), containsInAnyOrder("root.yml", "level1", "another"));
+
+        // Assert that null modification & creation date don't break getters (and so the serialization) since they can be null for directory
+        Assertions.assertDoesNotThrow(() -> {
+            list.forEach(fileAttr -> {
+                fileAttr.getLastModifiedTime();
+                fileAttr.getCreationTime();
+            });
+        });
         // Assert that '..' in path cannot be used as gcs do not use directory listing and traversal.
         assertThrows(FileNotFoundException.class, () -> {storageInterface.get(tenantId, new URI("/" + prefix + "/storage/level2/..")); });
 


### PR DESCRIPTION
Needed for namespace files to work under GCS. Currently creating any directory will break the whole namespace.