### PR TITLE
fix(mkdirs): replace stale in-memory directory cache with GCS existence check

### DIFF
--- a/src/main/java/io/kestra/storage/gcs/GcsStorage.java
+++ b/src/main/java/io/kestra/storage/gcs/GcsStorage.java
@@ -10,7 +10,6 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,8 +43,6 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @Plugin
 @Plugin.Id("gcs")
 public class GcsStorage implements StorageInterface, GcsConfig {
-    private final Set<String> createdDirectories = ConcurrentHashMap.newKeySet();
-
     private static final Logger log = LoggerFactory.getLogger(GcsStorage.class);
 
     private String bucket;
@@ -303,12 +300,11 @@ public class GcsStorage implements StorageInterface, GcsConfig {
                 currentPath.append(part).append("/");
                 String dir = currentPath.toString();
 
-                if (createdDirectories.add(dir)) {
+                if (!exists(blob(dir))) {
                     try {
                         BlobInfo blobInfo = BlobInfo.newBuilder(blob(dir)).build();
                         storage.create(blobInfo);
                     } catch (StorageException e) {
-                        createdDirectories.remove(dir);
                         log.warn("Failed to create directory: {}", dir, e);
                     }
                 }

--- a/src/test/java/io/kestra/storage/gcs/GcsStorageTest.java
+++ b/src/test/java/io/kestra/storage/gcs/GcsStorageTest.java
@@ -15,11 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GcsStorageTest extends StorageTestSuite {
 
-    /**
-     * Regression test for Bug 2: directory markers removed by deleteByPrefix must not be
-     * served from the stale in-memory cache on the next put, causing getAttributes to report
-     * the directory as absent even though objects exist underneath.
-     */
     @Test
     void directoryMarkerRecreatedAfterDeleteByPrefix() throws Exception {
         var tenantId = IdUtils.create();

--- a/src/test/java/io/kestra/storage/gcs/GcsStorageTest.java
+++ b/src/test/java/io/kestra/storage/gcs/GcsStorageTest.java
@@ -1,7 +1,47 @@
 package io.kestra.storage.gcs;
 
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
 import io.kestra.core.storage.StorageTestSuite;
+import io.kestra.core.storages.FileAttributes;
+import io.kestra.core.utils.IdUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GcsStorageTest extends StorageTestSuite {
-    // Launch test from StorageTestSuite
+
+    /**
+     * Regression test for Bug 2: directory markers removed by deleteByPrefix must not be
+     * served from the stale in-memory cache on the next put, causing getAttributes to report
+     * the directory as absent even though objects exist underneath.
+     */
+    @Test
+    void directoryMarkerRecreatedAfterDeleteByPrefix() throws Exception {
+        var tenantId = IdUtils.create();
+        var prefix = IdUtils.create();
+        var dirPath = "/" + prefix + "/a/b";
+        var firstFile = dirPath + "/c.txt";
+        var secondFile = dirPath + "/d.txt";
+        var content = "hello".getBytes();
+
+        // 1. put a file → mkdirs creates the "a/b/" marker
+        storageInterface.put(tenantId, null, new URI(firstFile), new ByteArrayInputStream(content));
+
+        // 2. delete everything under a/b/ → marker blob is removed from GCS
+        storageInterface.deleteByPrefix(tenantId, null, new URI(dirPath + "/"));
+
+        // 3. put another file under the same directory → mkdirs must recreate the marker
+        storageInterface.put(tenantId, null, new URI(secondFile), new ByteArrayInputStream(content));
+
+        // 4. getAttributes must not throw FileNotFoundException — the directory marker was recreated by mkdirs
+        var attrs = storageInterface.getAttributes(tenantId, null, new URI(dirPath));
+        assertThat(attrs.getType(), is(FileAttributes.FileType.Directory));
+        // the newly-put file must be reachable
+        assertTrue(storageInterface.exists(tenantId, null, new URI(secondFile)));
+    }
 }


### PR DESCRIPTION
## Summary

- Remove the unbounded `createdDirectories` `ConcurrentHashMap` set from `GcsStorage`
- In `mkdirs`, replace `createdDirectories.add(dir)` with `!exists(blob(dir))` — consult GCS directly before creating a marker blob
- Add regression test: `put` → `deleteByPrefix` → `put` → assert `getAttributes` succeeds and the file is reachable
- Remove orphaned `import java.util.concurrent.ConcurrentHashMap`

The old cache caused two distinct bugs: (1) a memory leak since every unique directory path written was retained for the process lifetime, and (2) a correctness failure where a directory deleted via `deleteByPrefix`/`delete`/`move` was never recreated on a subsequent `put` because the cache still held the stale entry, causing `getAttributes` to throw `FileNotFoundException` even though objects existed underneath.

closes: https://github.com/kestra-io/storage-gcs/issues/199

## Test plan

- [x] `./gradlew test` passes (65 tests, all green)
- [x] New test `directoryMarkerRecreatedAfterDeleteByPrefix` reproduces Bug 2 and passes with the fix