### PR TITLE
fix(storage): retry GCS batch submit on transient errors

### DIFF
--- a/src/main/java/io/kestra/storage/gcs/GcsStorage.java
+++ b/src/main/java/io/kestra/storage/gcs/GcsStorage.java
@@ -53,6 +53,12 @@ public class GcsStorage implements StorageInterface, GcsConfig {
     // GCS batch requests are limited to 100 operations per submit call.
     private static final int BATCH_DELETE_LIMIT = 100;
 
+    // The GCS JSON batch endpoint intermittently returns transient "server(s) are not
+    // responding" errors that the client does not retry on its own. Re-submit a fresh
+    // batch with a short backoff to absorb those before failing.
+    private static final int BATCH_SUBMIT_MAX_ATTEMPTS = 3;
+    private static final long BATCH_SUBMIT_RETRY_BACKOFF_MS = 500;
+
     private String bucket;
 
     private String path;
@@ -381,13 +387,13 @@ public class GcsStorage implements StorageInterface, GcsConfig {
     @Override
     public URI move(String tenantId, @Nullable String namespace, URI from, URI to) throws IOException {
         String path = getPath(tenantId, from);
-        StorageBatch batch = this.storage.batch();
+        Map<URI, BlobId> toDelete = new LinkedHashMap<>();
 
         if (getAttributes(tenantId, namespace, from).getType() == FileAttributes.FileType.File) {
             // move just a file
             BlobId source = blob(path);
             BlobId target = blob(tenantId, to);
-            moveFile(source, target, batch);
+            copyForMove(source, target, toDelete);
         } else {
             // move directories
             String prefix = (!path.endsWith("/")) ? path + "/" : path;
@@ -396,16 +402,16 @@ public class GcsStorage implements StorageInterface, GcsConfig {
             list.streamAll().forEach(blob ->
             {
                 BlobId target = blob(getPath(tenantId, to) + "/" + blob.getName().substring(prefix.length()));
-                moveFile(blob.getBlobId(), target, batch);
+                copyForMove(blob.getBlobId(), target, toDelete);
             });
         }
-        batch.submit();
+        batchDeleteWithRetry(toDelete);
         return createUri(to.getPath());
     }
 
-    private void moveFile(BlobId source, BlobId target, StorageBatch batch) {
+    private void copyForMove(BlobId source, BlobId target, Map<URI, BlobId> toDelete) {
         this.storage.copy(Storage.CopyRequest.newBuilder().setSource(source).setTarget(target).build());
-        batch.delete(source);
+        toDelete.put(URI.create("kestra://" + source.getName()), source);
     }
 
     @Override
@@ -466,20 +472,17 @@ public class GcsStorage implements StorageInterface, GcsConfig {
     }
 
     private void batchDelete(List<BlobId> blobIds) throws IOException {
-        var batch = storage.batch();
-        var results = new LinkedHashMap<URI, StorageBatchResult<Boolean>>();
+        var toDelete = new LinkedHashMap<URI, BlobId>();
         for (var blobId : blobIds) {
-            var uri = URI.create("kestra://" + blobId.getName());
-            results.put(uri, batch.delete(blobId));
+            toDelete.put(URI.create("kestra://" + blobId.getName()), blobId);
         }
-        bulkDelete(results, batch);
+        bulkDelete(toDelete);
     }
 
     @Override
     public List<URI> deleteByPrefix(String tenantId, @Nullable String namespace, URI storagePrefix) throws IOException {
         try {
-            StorageBatch batch = this.storage.batch();
-            Map<URI, StorageBatchResult<Boolean>> results = new HashMap<>();
+            Map<URI, BlobId> toDelete = new LinkedHashMap<>();
 
             String prefix = getPath(tenantId, storagePrefix);
 
@@ -487,10 +490,11 @@ public class GcsStorage implements StorageInterface, GcsConfig {
                 .list(bucket, Storage.BlobListOption.prefix(prefix));
 
             for (Blob blob : blobs.iterateAll()) {
-                results.put(URI.create("kestra://" + blob.getBlobId().getName().replaceFirst(tenantId, "").replaceAll("/$", "")), batch.delete(blob.getBlobId()));
+                BlobId blobId = blob.getBlobId();
+                toDelete.put(URI.create("kestra://" + blobId.getName().replaceFirst(tenantId, "").replaceAll("/$", "")), blobId);
             }
 
-            return bulkDelete(results, batch);
+            return bulkDelete(toDelete);
         } catch (StorageException e) {
             throw new IOException(e);
         }
@@ -498,45 +502,87 @@ public class GcsStorage implements StorageInterface, GcsConfig {
 
     private List<URI> deleteByPrefix(URI storagePrefix) throws IOException {
         try {
-            StorageBatch batch = this.storage.batch();
-            Map<URI, StorageBatchResult<Boolean>> results = new HashMap<>();
+            Map<URI, BlobId> toDelete = new LinkedHashMap<>();
 
             String prefix = getPath(storagePrefix);
 
             Page<Blob> blobs = this.storage.list(bucket, Storage.BlobListOption.prefix(prefix));
 
             for (Blob blob : blobs.iterateAll()) {
-                results.put(URI.create("kestra://" + blob.getBlobId().getName().replaceAll("/$", "")), batch.delete(blob.getBlobId()));
+                BlobId blobId = blob.getBlobId();
+                toDelete.put(URI.create("kestra://" + blobId.getName().replaceAll("/$", "")), blobId);
             }
 
-            return bulkDelete(results, batch);
+            return bulkDelete(toDelete);
         } catch (StorageException e) {
             throw new IOException(e);
         }
     }
 
-    private static List<URI> bulkDelete(Map<URI, StorageBatchResult<Boolean>> results, StorageBatch batch) throws IOException {
-        if (results.isEmpty()) {
+    private List<URI> bulkDelete(Map<URI, BlobId> toDelete) throws IOException {
+        if (toDelete.isEmpty()) {
             return List.of();
         }
 
-        batch.submit();
+        Map<URI, Boolean> results = batchDeleteWithRetry(toDelete);
 
-        if (!results.entrySet().stream().allMatch(r -> r.getValue() != null && r.getValue().get())) {
+        List<URI> failed = results.entrySet().stream()
+            .filter(e -> !Boolean.TRUE.equals(e.getValue()))
+            .map(Map.Entry::getKey)
+            .toList();
+
+        if (!failed.isEmpty()) {
             throw new IOException(
                 "Unable to delete all files, failed on [" +
-                    results
-                        .entrySet()
-                        .stream()
-                        .filter(r -> r.getValue() == null || !r.getValue().get())
-                        .map(r -> r.getKey().getPath())
-                        .collect(Collectors.joining(", "))
-                    +
+                    failed.stream().map(URI::getPath).collect(Collectors.joining(", ")) +
                     "]"
             );
         }
 
-        return new ArrayList<>(results.keySet());
+        return new ArrayList<>(toDelete.keySet());
+    }
+
+    /**
+     * Submits the given deletes as a GCS batch, rebuilding and re-submitting a fresh batch on
+     * transient {@link StorageException}s. A {@link StorageBatch} is single-use, so the batch is
+     * recreated on every attempt rather than re-submitting the same instance.
+     *
+     * @return per-URI deletion outcome ({@code true} when the object was deleted)
+     */
+    private Map<URI, Boolean> batchDeleteWithRetry(Map<URI, BlobId> toDelete) {
+        StorageException last = null;
+        for (int attempt = 1; attempt <= BATCH_SUBMIT_MAX_ATTEMPTS; attempt++) {
+            StorageBatch batch = this.storage.batch();
+            Map<URI, StorageBatchResult<Boolean>> results = new LinkedHashMap<>();
+            toDelete.forEach((uri, blobId) -> results.put(uri, batch.delete(blobId)));
+
+            try {
+                batch.submit();
+            } catch (StorageException e) {
+                last = e;
+                if (attempt < BATCH_SUBMIT_MAX_ATTEMPTS) {
+                    log.warn("GCS batch submit failed (attempt {}/{}), retrying: {}",
+                        attempt, BATCH_SUBMIT_MAX_ATTEMPTS, e.getMessage());
+                    sleepBackoff(attempt);
+                    continue;
+                }
+                throw e;
+            }
+
+            Map<URI, Boolean> outcome = new LinkedHashMap<>();
+            results.forEach((uri, result) -> outcome.put(uri, result != null && Boolean.TRUE.equals(result.get())));
+            return outcome;
+        }
+        throw last; // unreachable: the loop either returns or throws
+    }
+
+    private static void sleepBackoff(int attempt) {
+        try {
+            Thread.sleep(BATCH_SUBMIT_RETRY_BACKOFF_MS * attempt);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new StorageException(0, "Interrupted while retrying GCS batch submit", e);
+        }
     }
 
     private static URI createUri(String key) {


### PR DESCRIPTION
## Problem

CI on `main` intermittently fails (e.g. [run 27616695977](https://github.com/kestra-io/storage-gcs/actions/runs/27616695977/job/81654303241)) with:

```
java.io.IOException: com.google.cloud.storage.StorageException: server(s) are not responding
    at com.google.cloud.storage.StorageBatch$1.onFailure(StorageBatch.java:171)
```

The GCS JSON **batch** endpoint occasionally returns transient "server(s) are not responding" errors that the client does not retry on its own. This affects `deleteByPrefix`, `move`, and `purgeByLastModified` — any path that calls `StorageBatch.submit()`.

## Fix

A `StorageBatch` is single-use, so retrying requires rebuilding the batch each attempt. This centralizes that:

- **New `batchDeleteWithRetry(Map<URI, BlobId>)`** — builds a fresh `StorageBatch` per attempt, submits it, and on a transient `StorageException` recreates and retries (3 attempts, 500ms × attempt backoff) before failing.
- **`bulkDelete`** now takes `Map<URI, BlobId>` and delegates to the retry helper, keeping the original strict contract (throws `IOException` listing any objects that didn't delete).
- All three batch paths route through it: both `deleteByPrefix` overloads, `purgeByLastModified` (via `batchDelete`), and `move` (`moveFile` → `copyForMove`; copy stays synchronous, sources collected then deleted).

## Notes

- Chunking at `BATCH_DELETE_LIMIT` (100) is preserved.
- Strict delete semantics kept: a `false` result still counts as failure. Safe because the transient error fails the whole batch (nothing applied), so retries re-delete everything successfully.
- Not run locally — the test suite requires live GCS credentials (CI only). Compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)