### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/storage/gcs/GcsConfig.java
+++ b/src/main/java/io/kestra/storage/gcs/GcsConfig.java
@@ -27,7 +27,7 @@ public interface GcsConfig {
         title = "The GCS service account key, as a JSON string.",
         description = "If not provided, the default credentials will be used."
     )
-    @PluginProperty
+    @PluginProperty(secret = true)
     String getServiceAccount();
 
     @Schema(

--- a/src/main/java/io/kestra/storage/gcs/GcsStorage.java
+++ b/src/main/java/io/kestra/storage/gcs/GcsStorage.java
@@ -23,6 +23,7 @@ import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.*;
 
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.storages.FileAttributes;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.storages.StorageObject;
@@ -60,6 +61,7 @@ public class GcsStorage implements StorageInterface, GcsConfig {
 
     private String path;
 
+    @PluginProperty(secret = true)
     private String serviceAccount;
 
     private String projectId;


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Missing @PluginProperty(secret=true) on serviceAccount credential field (`src/main/java/io/kestra/storage/gcs/GcsConfig.java:30`)
  - Fix: Changed `@PluginProperty` to `@PluginProperty(secret = true)` on `getServiceAccount()` in `GcsConfig.java`, and added `@PluginProperty(secret = true)` directly on the concrete `serviceAccount` field in `GcsStorage.java` to ensure the annotation processor masks the GCS service account JSON key in logs, API responses, and the UI.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/storage-gcs/issues/216
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
